### PR TITLE
fix: Use AccessPattern throughout consistently

### DIFF
--- a/docs/start-up/core-concepts.md
+++ b/docs/start-up/core-concepts.md
@@ -270,7 +270,9 @@ def process_tasks(world: ScopedAccess) -> None:
 
 - `reads`: Component types the system reads
 - `writes`: Component types the system writes
-- Both are **optional**—omit for full access during prototyping
+- Both are optional. `@system()` means full read/write access.
+- If you declare only one side, the omitted side defaults to no access.
+- `writes=()` means no write access.
 
 **Querying Entities:**
 
@@ -502,6 +504,12 @@ Systems can optionally declare which components they access for validation and d
 def prototype(world: ScopedAccess) -> None:
     # Can read/write anything
     pass
+
+# Reads declared, writes omitted -> no writes allowed
+@system(reads=(Task,))
+def observer(world: ScopedAccess) -> None:
+    for _, task in world(Task):
+        _ = task
 
 # Production: declared access for validation
 @system(reads=(Task, TokenBudget), writes=(Task, TokenBudget))

--- a/docs/start-up/first-steps.md
+++ b/docs/start-up/first-steps.md
@@ -373,7 +373,7 @@ Ready to dive deeper?
 
 **Q: Do I need to specify `reads` and `writes`?**
 
-No! They're optional. For prototyping, just use `@system()`. Add declarations later for documentation and optimization.
+No. For prototyping, use `@system()` for full read/write access. If you declare only one side, the omitted side defaults to no access (for example `@system(reads=(Task,))` means read-only for `Task` unless you also declare writes).
 
 **Q: Can systems be async?**
 

--- a/docs/system/scheduling.md
+++ b/docs/system/scheduling.md
@@ -245,6 +245,12 @@ def debug_system(access):
     pass
 ```
 
+Defaulting behavior:
+
+- `@system()` -> full read/write access
+- `@system(reads=(Position,))` -> reads `Position`, writes nothing
+- `writes=()` -> explicit no-write access
+
 !!! tip "When to Declare Access"
     - **Always declare** when you want validation and documentation
     - **Skip declarations** for quick prototyping or simple scripts

--- a/docs/system/systems.md
+++ b/docs/system/systems.md
@@ -137,6 +137,13 @@ def quick_prototype(world: ScopedAccess) -> None:
     pass
 ```
 
+Defaulting rules are explicit:
+
+- `@system()` (both omitted) -> full read and write access
+- If one side is declared and the other omitted, the omitted side becomes no access
+- `writes=()` is an explicit no-write declaration
+- `@system.readonly()` defaults to full read access, writes are always blocked
+
 !!! tip "When to Declare Access"
     - **Skip declarations** for quick prototyping or simple scripts
     - **Add declarations** when you want validation and documentation

--- a/src/agentecs/core/__init__.py
+++ b/src/agentecs/core/__init__.py
@@ -27,10 +27,12 @@ from agentecs.core.identity import EntityId, SystemEntity
 from agentecs.core.query import (
     AccessPattern,
     AllAccess,
+    NoAccess,
     Query,
     QueryAccess,
     TypeAccess,
     normalize_access,
+    normalize_reads_and_writes,
     queries_disjoint,
 )
 from agentecs.core.system import (
@@ -76,8 +78,10 @@ __all__ = [
     "Query",
     "AccessPattern",
     "AllAccess",
+    "NoAccess",
     "TypeAccess",
     "QueryAccess",
     "queries_disjoint",
     "normalize_access",
+    "normalize_reads_and_writes",
 ]

--- a/src/agentecs/core/query/__init__.py
+++ b/src/agentecs/core/query/__init__.py
@@ -1,16 +1,29 @@
 """Query functionality: query builder and access patterns."""
 
-from agentecs.core.query.models import AccessPattern, AllAccess, Query, QueryAccess, TypeAccess
-from agentecs.core.query.operations import normalize_access, queries_disjoint
+from agentecs.core.query.models import (
+    AccessPattern,
+    AllAccess,
+    NoAccess,
+    Query,
+    QueryAccess,
+    TypeAccess,
+)
+from agentecs.core.query.operations import (
+    normalize_access,
+    normalize_reads_and_writes,
+    queries_disjoint,
+)
 
 __all__ = [
     # Models
     "Query",
     "AccessPattern",
     "AllAccess",
+    "NoAccess",
     "TypeAccess",
     "QueryAccess",
     # Operations
     "queries_disjoint",
     "normalize_access",
+    "normalize_reads_and_writes",
 ]

--- a/src/agentecs/core/query/models.py
+++ b/src/agentecs/core/query/models.py
@@ -64,7 +64,14 @@ class Query:
 
 @dataclass(frozen=True)
 class AllAccess:
-    """Dev mode: unrestricted access, disables parallelization for this system."""
+    """Unrestricted component access."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class NoAccess:
+    """No component access."""
 
     pass
 
@@ -93,4 +100,4 @@ class QueryAccess:
         return frozenset(result)
 
 
-AccessPattern = AllAccess | TypeAccess | QueryAccess
+AccessPattern = AllAccess | TypeAccess | QueryAccess | NoAccess

--- a/src/agentecs/core/query/operations.py
+++ b/src/agentecs/core/query/operations.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from typing import cast
 
-from agentecs.core.query.models import AccessPattern, AllAccess, Query, QueryAccess, TypeAccess
+from agentecs.core.query.models import (
+    AccessPattern,
+    AllAccess,
+    NoAccess,
+    Query,
+    QueryAccess,
+    TypeAccess,
+)
 
 
 def queries_disjoint(q1: Query, q2: Query) -> bool:
@@ -27,12 +34,15 @@ def queries_disjoint(q1: Query, q2: Query) -> bool:
     return any(t in q2.excluded for t in q1.required) or any(t in q1.excluded for t in q2.required)
 
 
-def normalize_access(spec: tuple[type, ...] | Query | AllAccess | None) -> AccessPattern:
+def normalize_access(
+    spec: tuple[type, ...] | tuple[Query, ...] | Query | AllAccess | NoAccess | None,
+) -> AccessPattern:
     """Convert various access specifications to normalized AccessPattern.
 
     Handles multiple input formats:
-    - None or empty tuple -> TypeAccess with no types
-    - AllAccess -> passthrough
+    - None -> AllAccess
+    - Empty tuple -> NoAccess
+    - AllAccess or NoAccess -> passthrough
     - Single Query -> QueryAccess
     - Tuple of types -> TypeAccess
     - Tuple of queries -> QueryAccess
@@ -41,21 +51,49 @@ def normalize_access(spec: tuple[type, ...] | Query | AllAccess | None) -> Acces
         spec: Access specification in various formats.
 
     Returns:
-        Normalized AccessPattern (AllAccess, TypeAccess, or QueryAccess).
+        Normalized AccessPattern (AllAccess, NoAccess, TypeAccess, or QueryAccess).
 
     Raises:
         TypeError: If spec is not a recognized access specification format.
     """
-    if spec is None or spec == ():
-        return TypeAccess(frozenset())
-    if isinstance(spec, AllAccess):
+    if spec is None:
+        return AllAccess()
+    if isinstance(spec, (AllAccess, NoAccess)):
         return spec
     if isinstance(spec, Query):
         return QueryAccess(queries=(spec,))
     if isinstance(spec, tuple):
+        if len(spec) == 0:
+            return NoAccess()
         # Check if tuple of types or tuple of queries
         if all(isinstance(t, type) for t in spec):
-            return TypeAccess(frozenset(spec))
+            return TypeAccess(cast(tuple[type, ...], spec))
         if all(isinstance(t, Query) for t in spec):
             return QueryAccess(queries=cast(tuple[Query, ...], spec))
     raise TypeError(f"Invalid access specification: {spec}")
+
+
+def normalize_reads_and_writes(
+    reads: tuple[type, ...] | tuple[Query, ...] | Query | AllAccess | NoAccess | None,
+    writes: tuple[type, ...] | tuple[Query, ...] | Query | AllAccess | NoAccess | None,
+) -> tuple[AccessPattern, AccessPattern]:
+    """Normalize reads and writes specifications to AccessPatterns.
+
+    If reads and writes are None (not given), defaults to AllAccess.
+    If either is given and the other is None, the other defaults to NoAccess.
+
+    This ensures that reads=(A,) and writes=None is treated as reads=(A,) and
+    writes=NoAccess(), avoiding accidental implicit write access.
+
+    Args:
+        reads: Access specification for reads.
+        writes: Access specification for writes.
+
+    Returns:
+        Tuple of normalized AccessPatterns for reads and writes.
+    """
+    if reads is None and writes is None:
+        return AllAccess(), AllAccess()
+    parsed_reads = NoAccess() if reads is None else normalize_access(reads)
+    parsed_writes = NoAccess() if writes is None else normalize_access(writes)
+    return parsed_reads, parsed_writes

--- a/src/agentecs/world/world.py
+++ b/src/agentecs/world/world.py
@@ -344,7 +344,7 @@ class World:
 
         validate_result_access(
             result_buffer,
-            descriptor.writable_types(),
+            descriptor.writes,
             descriptor.name,
         )
 


### PR DESCRIPTION
## Description

- Fix AccessPattern to include a NoAccess
- Make logic work more consistently when it's NoAccess and when it's AllAccess
- Downstream try to use AccessPatterns for semantics
- tests and docs
